### PR TITLE
Fixed TimeVarEff backwards compatibility issues

### DIFF
--- a/urbs/input.py
+++ b/urbs/input.py
@@ -122,6 +122,8 @@ def read_excel(input_files):
                                        keys=[support_timeframe],
                                        names=['support_timeframe'])
                 ef.append(eff_factor)
+            else:
+                ef.append(pd.DataFrame())
 
         # prepare input data
         # split columns by dots '.', so that 'DE.Elec' becomes the two-level


### PR DESCRIPTION
It is now possible to run input sheets where no file contains any TimeVarEff sheet in the intertemporal urbs